### PR TITLE
Document Output and Fix ProcessMetrics 

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,4 +89,18 @@ Any list of signals.
 
 Output
 ------
-TODO: document this
+metrics about the process.
+
+```
+{
+  'pid': '636',
+  'cpu_percentage': 0.0,
+  'cmd_line': '/Applications/TestApp.app',
+  'num_ctx_switches': pctxsw(voluntary=2623955, involuntary=0),
+  'memory_percent': 6.918835639953613,
+  'num_fds': 137,
+  'virtual_memory': 8270610432,
+  'is_running': True,
+  'children': [<psutil.Process(pid=645, name='fsnotifier') at 4384871256>]
+}
+```

--- a/process_metrics_block.py
+++ b/process_metrics_block.py
@@ -1,6 +1,6 @@
 import psutil
 from nio.block.base import Block
-from nio.properties import ObjectProperty, Property, \
+from nio.properties import ObjectProperty, IntProperty, \
     PropertyHolder, BoolProperty, VersionProperty
 from nio.signal.base import Signal
 
@@ -29,7 +29,7 @@ class ProcessMetrics(Block):
 
     version = VersionProperty('0.1.0', min_version='0.1.0')
     menu = ObjectProperty(Menu, title='Menu', default=Menu())
-    pid_expr = Property(title='PID', allow_none=True)
+    pid = IntProperty(title='PID', allow_none=False)
 
     def __init__(self):
         super().__init__()
@@ -38,7 +38,7 @@ class ProcessMetrics(Block):
     def process_signals(self, signals):
         results = []
         for sig in signals:
-            pid = self.pid_expr(sig)
+            pid = self.pid(sig)
             stats = self._collect_stats(pid)
             if stats:
                 results.append(Signal(stats))

--- a/process_metrics_block.py
+++ b/process_metrics_block.py
@@ -1,13 +1,8 @@
 import psutil
-
 from nio.block.base import Block
-from nio.signal.base import Signal
-from nio.command import command
-from nio.util.discovery import discoverable
 from nio.properties import ObjectProperty, Property, \
     PropertyHolder, BoolProperty, VersionProperty
-from nio.modules.scheduler import Job
-
+from nio.signal.base import Signal
 
 RETRY_LIMIT = 3
 
@@ -30,7 +25,6 @@ class NoPIDException(Exception):
     pass
 
 
-@discoverable
 class ProcessMetrics(Block):
 
     version = VersionProperty('0.1.0', min_version='0.1.0')
@@ -51,10 +45,9 @@ class ProcessMetrics(Block):
         if results:
             self.notify_signals(results)
 
-
     def _collect_stats(self, pid):
         result = {'pid': pid}
-        proc = psutil.Process(pid)
+        proc = psutil.Process(int(pid))
 
         try:
             if self.menu().cpu_percent():

--- a/process_metrics_block.py
+++ b/process_metrics_block.py
@@ -47,7 +47,7 @@ class ProcessMetrics(Block):
 
     def _collect_stats(self, pid):
         result = {'pid': pid}
-        proc = psutil.Process(int(pid))
+        proc = psutil.Process(pid)
 
         try:
             if self.menu().cpu_percent():

--- a/system_metrics_block.py
+++ b/system_metrics_block.py
@@ -1,24 +1,20 @@
-import os
-import re
-import psutil
 import ctypes
-import subprocess
+import os
 import platform
+import re
+import subprocess
 from datetime import datetime
-import pickle
+
+import psutil
 from nio.block.base import Block
-from nio.signal.base import Signal
 from nio.command import command
-from nio.util.discovery import discoverable
-from nio.properties.object import ObjectProperty
-from nio.properties.holder import PropertyHolder
 from nio.properties.bool import BoolProperty
-from nio.properties.timedelta import TimeDeltaProperty
+from nio.properties.holder import PropertyHolder
+from nio.properties.object import ObjectProperty
 from nio.properties.version import VersionProperty
-from nio.modules.scheduler import Job
+from nio.signal.base import Signal
+
 from .sensors import Sensors
-
-
 
 RETRY_LIMIT = 3
 
@@ -46,7 +42,6 @@ class Menu(PropertyHolder):
 @command('timestamp')
 @command('cpu')
 @command('report')
-@discoverable
 class SystemMetrics(Block):
 
     version = VersionProperty('0.1.0', min_version='0.1.0')

--- a/tests/test_process_metrics_block.py
+++ b/tests/test_process_metrics_block.py
@@ -35,7 +35,7 @@ class TestProcessMetricsBlock(NIOBlockTestCase):
         event = Event()
         blk = EventProcessMetrics(event)
         self.configure_block(blk, {
-            'pid_expr': "{{ $pid }}"
+            'pid': "{{ $pid }}"
         })
         the_pid = os.getpid()
         blk.start()


### PR DESCRIPTION
Converting pid to an int fixes the process_metrics block, which seemed to be non-functional?
Also document process_metrics output.

Resolves #14 